### PR TITLE
Adds support for vendorExtensions configuration that was introduced by Swagger-UI 3.5.0

### DIFF
--- a/Swagger.Net/Application/SwaggerUiConfig.cs
+++ b/Swagger.Net/Application/SwaggerUiConfig.cs
@@ -33,6 +33,7 @@ namespace Swagger.Net.Application
                 { "%(DefaultModelExpandDepth)", "0" },
                 { "%(UImaxDisplayedTags)", "100" },
                 { "%(UIfilter)", "''" },
+                { "%(ShowExtensions)", "false" },
                 { "%(SupportedSubmitMethods)", "get|put|post|delete|options|head|patch" },
                 { "%(OAuth2Enabled)", "false" },
                 { "%(OAuth2ClientId)", "" },
@@ -128,6 +129,11 @@ namespace Swagger.Net.Application
         public void UIfilter(string filter)
         {
             _templateParams["%(UIfilter)"] = filter;
+        }
+
+        public void ShowExtensions(bool value)
+        {
+            _templateParams["%(ShowExtensions)"] = value.ToString().ToLower();
         }
 
         public void SupportedSubmitMethods(params string[] methods)

--- a/Swagger.Net/SwaggerUi/CustomAssets/index.html
+++ b/Swagger.Net/SwaggerUi/CustomAssets/index.html
@@ -105,6 +105,7 @@
         defaultModelExpandDepth: '%(DefaultModelExpandDepth)',
         maxDisplayedTags: %(UImaxDisplayedTags),
         filter: %(UIfilter),
+        showExtensions: ('%(ShowExtensions)' == 'true'),
         supportedSubmitMethods: arrayFrom('%(SupportedSubmitMethods)'),
         discoveryUrlSelector: ('%(DiscoveryUrlSelector)' == 'true'),
         oAuth2Enabled: ('%(OAuth2Enabled)' == 'true'),
@@ -148,6 +149,7 @@
             defaultModelExpandDepth: swaggerNetConfig.defaultModelExpandDepth,
             maxDisplayedTags: swaggerNetConfig.maxDisplayedTags,
             filter: swaggerNetConfig.filter,
+            showExtensions: swaggerNetConfig.showExtensions,
             validatorUrl: swaggerNetConfig.validatorUrl,
             oauth2RedirectUrl: window.location.href.replace('index', 'oauth2-redirect-html').split('#')[0],
             onComplete: function (swaggerApi, swaggerUi) {

--- a/Tests/Swagger.Net.Tests/SwaggerUi/SwaggerUiTests.cs
+++ b/Tests/Swagger.Net.Tests/SwaggerUi/SwaggerUiTests.cs
@@ -84,6 +84,7 @@ namespace Swagger.Net.Tests.SwaggerUi
                     c.DefaultModelRendering(DefaultModelRender.Model);
                     c.DefaultModelExpandDepth(1);
                     c.BooleanValues(new[] { "1", "0" });
+                    c.ShowExtensions(true);
                     c.SupportedSubmitMethods("GET", "HEAD");
                     c.EnableOAuth2Support("test-client-id", "test-realm", "Swagger UI");
                 });
@@ -93,6 +94,7 @@ namespace Swagger.Net.Tests.SwaggerUi
             StringAssert.Contains("docExpansion: 'full'", content);
             StringAssert.Contains("booleanValues: arrayFrom('1|0')", content);
             StringAssert.Contains("supportedSubmitMethods: arrayFrom('get|head')", content);
+            StringAssert.Contains("showExtensions: 'true'", content);
         }
 
         [Test]

--- a/Tests/Swagger.Net.Tests/SwaggerUi/SwaggerUiTests.cs
+++ b/Tests/Swagger.Net.Tests/SwaggerUi/SwaggerUiTests.cs
@@ -94,7 +94,7 @@ namespace Swagger.Net.Tests.SwaggerUi
             StringAssert.Contains("docExpansion: 'full'", content);
             StringAssert.Contains("booleanValues: arrayFrom('1|0')", content);
             StringAssert.Contains("supportedSubmitMethods: arrayFrom('get|head')", content);
-            StringAssert.Contains("showExtensions: 'true'", content);
+            StringAssert.Contains("showExtensions: ('true' == 'true')", content);
         }
 
         [Test]


### PR DESCRIPTION
We can now use the config ShowExtensions when enabling the Swagger-UI. It's false by default.

`            config
                .EnableSwagger(c =>
                {
                }).EnableSwaggerUi(c =>
                {
                    c.ShowExtensions(true);
                });
`

When it's true, an extensions section will be displayed and all vendor extensions will be shown:

![extensions](https://user-images.githubusercontent.com/5147884/33617056-bd748768-d9ac-11e7-9cfd-e2a3edec0cdf.PNG)
