### PR TITLE
Correcting how grouping of controllers works for swagger-ui 3;

### DIFF
--- a/Swagger.Net/Swagger.Net.csproj
+++ b/Swagger.Net/Swagger.Net.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Application\SwaggerDocsConfig.cs" />
     <Compile Include="Application\HttpConfigurationExtensions.cs" />
     <Compile Include="Swagger\Annotations\ApplySwaggerResponseAttributes.cs" />
+    <Compile Include="Swagger\Comparers\TagNameEqualityComparer.cs" />
     <Compile Include="Swagger\Extensions\ApiParameterDescriptionExtensions.cs" />
     <Compile Include="Swagger\XmlComments\XmlCommentsIdHelper.cs" />
     <Compile Include="Swagger\IModelFilter.cs" />

--- a/Swagger.Net/Swagger/Comparers/TagNameEqualityComparer.cs
+++ b/Swagger.Net/Swagger/Comparers/TagNameEqualityComparer.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+
+namespace Swagger.Net
+{
+    public class TagNameEqualityComparer : IEqualityComparer<Tag>
+    {
+        public bool Equals(Tag x, Tag y)
+        {
+            return x.name.Equals(y.name);
+        }
+
+        public int GetHashCode(Tag obj)
+        {
+            return obj.name.GetHashCode();
+        }
+    }
+}

--- a/Tests/Swagger.Net.Tests/Swagger/CoreTests.cs
+++ b/Tests/Swagger.Net.Tests/Swagger/CoreTests.cs
@@ -504,18 +504,35 @@ namespace Swagger.Net.Tests.Swagger
         }
 
         [Test]
-        public void It_exposes_config_to_customize_the_ordering_of_action_groups()
+        public void It_sorts_controllers_alphabetically_as_default()
         {
             SetUpDefaultRoutesFor(new[] { typeof(ProductsController), typeof(CustomersController) });
+
+            var swagger = GetContent<JObject>(TEMP_URI.DOCS);
+            var tags = swagger["tags"]
+                .Value<JArray>()
+                .Children<JObject>()
+                .SelectMany(j => j.Properties())
+                .Select(p => p.Value.ToString());
+
+            CollectionAssert.AreEqual(new[] { "Customers", "Products" }, tags);
+        }
+
+        [Test]
+        public void It_exposes_config_to_customize_the_ordering_of_action_groups()
+        {
+            SetUpDefaultRoutesFor(new[] { typeof(CustomersController), typeof(ProductsController) });
             SetUpHandler(c => c.OrderActionGroupsBy(new DescendingAlphabeticComparer()));
 
             var swagger = GetContent<JObject>(TEMP_URI.DOCS);
-            var paths = swagger["paths"].Value<JObject>()
-                .Properties()
-                .Select(prop => prop.Name);
+            var tags = swagger["tags"]
+                .Value<JArray>()
+                .Children<JObject>()
+                .SelectMany(j => j.Properties())
+                .Select(p => p.Value.ToString());
 
-            CollectionAssert.AreEqual(new[] { "/products", "/products/{id}", "/customers", "/customers/{id}" }, paths);
-       }
+            CollectionAssert.AreEqual(new[] { "Products", "Customers" }, tags);
+        }
 
         [Test]
         public void It_exposes_config_to_post_modify_the_document()


### PR DESCRIPTION
I'm not entirely sure of the goal of the existing handling of tags via `ModelFilters`, so please correct me if this is going against the goal of them.

SwaggerUI 3 uses `tags` to handle grouping of the operations (It does not adhere to the ordering of the operations for grouping when the `tags` property is set.).  It uses a fall through system, preferring to use the top level `/tags` element, before falling back to the `paths/<path>/<httpmethod>/tags` elements.  The existing Swashbuckle codebase did not populate the top level `tags`, which allowed for the ordering system in place to work, whereas this new codebase has.

This change more or less forces population of the top level `tags` element using the existing `GroupingKeySelector` and `GroupingKeyComparer` configuration system.

The other route is to drop the top level `tags` element entirely, and fall back to the existing Swashbuckle way of doing things.