### PR TITLE
Expose ability to override the operation id via configuration;

### DIFF
--- a/Swagger.Net/Application/SwaggerDocsConfig.cs
+++ b/Swagger.Net/Application/SwaggerDocsConfig.cs
@@ -42,6 +42,7 @@ namespace Swagger.Net.Application
         private Func<IEnumerable<ApiDescription>, ApiDescription> _conflictingActionsResolver;
         private Func<HttpRequestMessage, string> _rootUrlResolver;
         private ApiKeySchemeBuilder _apiKeySchemeBuilder = null;
+        private Func<ApiDescription, string> _operationIdResolver = null;
 
         private Func<ISwaggerProvider, ISwaggerProvider> _customProviderFactory;
 
@@ -274,6 +275,11 @@ namespace Swagger.Net.Application
             _conflictingActionsResolver = conflictingActionsResolver;
         }
 
+        public void OperationIdResolver(Func<ApiDescription, string> operationIdResolver)
+        {
+            _operationIdResolver = operationIdResolver;
+        }
+
         public void RootUrl(Func<HttpRequestMessage, string> rootUrlResolver)
         {
             _rootUrlResolver = rootUrlResolver;
@@ -327,7 +333,8 @@ namespace Swagger.Net.Application
                 ignoreIsSpecifiedMembers: _ignoreIsSpecifiedMembers,
                 operationFilters: operationFilters,
                 documentFilters: _documentFilters.Select(factory => factory()).ToList(),
-                conflictingActionsResolver: _conflictingActionsResolver
+                conflictingActionsResolver: _conflictingActionsResolver,
+                operationIdResolver: _operationIdResolver
             );
 
             var defaultProvider = new SwaggerGenerator(

--- a/Swagger.Net/Swagger/SwaggerGenerator.cs
+++ b/Swagger.Net/Swagger/SwaggerGenerator.cs
@@ -49,7 +49,7 @@ namespace Swagger.Net
 
             var tags = apiDescriptions
                 .OrderBy(_options.GroupingKeySelector, _options.GroupingKeyComparer)
-                .Select(a => new Tag {description = a.Documentation, name = _options.GroupingKeySelector(a) })
+                .Select(a => new Tag { description = a.Documentation, name = _options.GroupingKeySelector(a) })
                 .Distinct(new TagNameEqualityComparer())
                 .ToList();
 
@@ -170,7 +170,7 @@ namespace Swagger.Net
             var operation = new Operation
             {
                 tags = new[] { _options.GroupingKeySelector(apiDesc) },
-                operationId = this.GetUniqueFriendlyId(apiDesc, operationNames),
+                operationId = this.GetUniqueOperationId(apiDesc, operationNames),
                 description = description?.Description,
                 summary = description?.Summary,
                 produces = apiDesc.Produces().ToList(),
@@ -188,23 +188,32 @@ namespace Swagger.Net
             return operation;
         }
 
-        public string GetUniqueFriendlyId(ApiDescription apiDesc, HashSet<string> operationNames)
+        public string GetUniqueOperationId(ApiDescription apiDesc, HashSet<string> operationNames)
         {
-            string friendlyId = apiDesc.FriendlyId();
-
-            if (operationNames.Contains(friendlyId))
+            string operationId;
+            if (_options.OperationIdResolver != null)
             {
-                friendlyId = apiDesc.FriendlyId2();
+                operationId = _options.OperationIdResolver(apiDesc);
+            }
+            else
+            {
+                // default behaviour
+                operationId = apiDesc.FriendlyId();
+                if (operationNames.Contains(operationId))
+                {
+                    operationId = apiDesc.FriendlyId2();
+                }
+
+                var nextFriendlyIdPostfix = 1;
+                while (operationNames.Contains(operationId))
+                {
+                    operationId = $"{apiDesc.FriendlyId2()}_{nextFriendlyIdPostfix}";
+                    nextFriendlyIdPostfix++;
+                }
             }
 
-            int nextFriendlyIdPostfix = 1;
-            while (operationNames.Contains(friendlyId))
-            {
-                friendlyId = string.Format("{0}_{1}", apiDesc.FriendlyId2(), nextFriendlyIdPostfix);
-                nextFriendlyIdPostfix++;
-            }
-            operationNames.Add(friendlyId);
-            return friendlyId;
+            operationNames.Add(operationId);
+            return operationId;
         }
 
         private string GetParameterLocation(ApiDescription apiDesc, ApiParameterDescription paramDesc)

--- a/Swagger.Net/Swagger/SwaggerGeneratorOptions.cs
+++ b/Swagger.Net/Swagger/SwaggerGeneratorOptions.cs
@@ -26,8 +26,8 @@ namespace Swagger.Net
             bool ignoreIsSpecifiedMembers = false,
             IEnumerable<IOperationFilter> operationFilters = null,
             IEnumerable<IDocumentFilter> documentFilters = null,
-            Func<IEnumerable<ApiDescription>, ApiDescription> conflictingActionsResolver = null
-            )
+            Func<IEnumerable<ApiDescription>, ApiDescription> conflictingActionsResolver = null,
+            Func<ApiDescription, string> operationIdResolver = null)
         {
             VersionSupportResolver = versionSupportResolver;
             Schemes = schemes;
@@ -48,6 +48,7 @@ namespace Swagger.Net
             OperationFilters = operationFilters ?? new List<IOperationFilter>();
             DocumentFilters = documentFilters ?? new List<IDocumentFilter>();
             ConflictingActionsResolver = conflictingActionsResolver ?? DefaultConflictingActionsResolver;
+            OperationIdResolver = operationIdResolver;
         }
 
         public Func<ApiDescription, string, bool> VersionSupportResolver { get; private set; }
@@ -81,6 +82,8 @@ namespace Swagger.Net
         public bool ApplyFiltersToAllSchemas { get; private set; }
 
         public bool IgnoreIsSpecifiedMembers { get; private set; }
+
+        public Func<ApiDescription, string> OperationIdResolver {get; }
 
         public IEnumerable<IOperationFilter> OperationFilters { get; private set; }
 

--- a/Tests/Swagger.Net.Tests/CoreUnitTests/ApiDescriptionExtensionsTests.cs
+++ b/Tests/Swagger.Net.Tests/CoreUnitTests/ApiDescriptionExtensionsTests.cs
@@ -47,7 +47,7 @@ namespace Swagger.Net.Tests.CoreUnitTests
 
             var operationNames = new HashSet<string> { friendlyId, friendlyId2 };
             var swaggerGenerator = new SwaggerGenerator(null, null, null);
-            string uniqueFriendlyId = swaggerGenerator.GetUniqueFriendlyId(apiDesc, operationNames);
+            string uniqueFriendlyId = swaggerGenerator.GetUniqueOperationId(apiDesc, operationNames);
             Assert.AreNotEqual(friendlyId2, uniqueFriendlyId);
         }
     }

--- a/Tests/Swagger.Net.Tests/Swagger/CoreTests.cs
+++ b/Tests/Swagger.Net.Tests/Swagger/CoreTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Text.RegularExpressions;
 using System.Web.Http;
 
 namespace Swagger.Net.Tests.Swagger
@@ -600,6 +601,27 @@ namespace Swagger.Net.Tests.Swagger
                     title = "Test API",
                 });
             Assert.AreEqual(expected.ToString().ToUpper(), info.ToString().ToUpper());
+        }
+
+        [Test]
+        public void It_exposes_config_to_override_operation_id_generation()
+        {
+            SetUpDefaultRouteFor<ProductsController>();
+            SetUpHandler(c =>
+            {
+                c.OperationIdResolver(d =>
+                {
+                    var routeClean = Regex.Replace(d.Route.RouteTemplate, "[\\W]", "_");
+                    return $"{d.HttpMethod.ToString()}_{routeClean}";
+                });
+            });
+
+            var swagger = GetContent<JObject>(TEMP_URI.DOCS);
+            var getProductsOperationId = swagger["paths"]["/products"]["get"]["operationId"];
+            var postProductOperationId = swagger["paths"]["/products"]["post"]["operationId"];
+
+            Assert.AreEqual("GET_products__id_", getProductsOperationId.Value<string>());
+            Assert.AreEqual("POST_products__id_", postProductOperationId.Value<string>());
         }
 
         [Test]


### PR DESCRIPTION
I wanted to allow the user to have more control over not being forced to have the internal controller/action names being directly used to generate the operation ids (the current default behaviour).  This PR exposes the ability to override the default behaviour with a user defined resolver.