### PR TITLE
Resolved oauth redirect_url issue

### DIFF
--- a/Swagger.Net/SwaggerUi/CustomAssets/index.html
+++ b/Swagger.Net/SwaggerUi/CustomAssets/index.html
@@ -153,7 +153,7 @@
             filter: swaggerNetConfig.filter,
             showExtensions: swaggerNetConfig.showExtensions,
             validatorUrl: swaggerNetConfig.validatorUrl,
-            oauth2RedirectUrl: window.location.href.replace('index', 'oauth2-redirect-html').split('#')[0],
+            oauth2RedirectUrl: (window.location.origin + window.location.pathname).replace('/index', '/oauth2-redirect-html').split('#')[0],
             onComplete: function (swaggerApi, swaggerUi) {
                 window.swaggerApi = swaggerApi;
                 swaggerNetConfig.customScripts.forEach(function (script) {

--- a/Swagger.Net/SwaggerUi/CustomAssets/index.html
+++ b/Swagger.Net/SwaggerUi/CustomAssets/index.html
@@ -153,7 +153,7 @@
             filter: swaggerNetConfig.filter,
             showExtensions: swaggerNetConfig.showExtensions,
             validatorUrl: swaggerNetConfig.validatorUrl,
-            oauth2RedirectUrl: (window.location.origin + window.location.pathname).replace('/index', '/oauth2-redirect-html').split('#')[0],
+            oauth2RedirectUrl: (window.location.origin + window.location.pathname).replace('/index', '/oauth2-redirect-html'),
             onComplete: function (swaggerApi, swaggerUi) {
                 window.swaggerApi = swaggerApi;
                 swaggerNetConfig.customScripts.forEach(function (script) {


### PR DESCRIPTION
Multi-version swagger implementations currently break as the redirect url is preserving the query string parameters from the calling page.

This resolves that by excluding additional query string arguments.