### PR TITLE
Correcting range min and max values to be properly tpyed by range property types;

### DIFF
--- a/Swagger.Net/Swagger/Extensions/SchemaExtensions.cs
+++ b/Swagger.Net/Swagger/Extensions/SchemaExtensions.cs
@@ -24,11 +24,8 @@ namespace Swagger.Net
         {
             if (attribute is RangeAttribute range)
             {
-                if (double.TryParse(range.Maximum.ToString(), out double maximum))
-                    schema.maximum = maximum;
-
-                if (double.TryParse(range.Minimum.ToString(), out double minimum))
-                    schema.minimum = minimum;
+                schema.minimum = range.Minimum;
+                schema.maximum = range.Maximum;
             }
         }
 

--- a/Swagger.Net/Swagger/SwaggerDocument.cs
+++ b/Swagger.Net/Swagger/SwaggerDocument.cs
@@ -268,11 +268,11 @@ namespace Swagger.Net
 
         public int? multipleOf;
 
-        public double? maximum;
+        public object maximum;
 
         public bool? exclusiveMaximum;
 
-        public double? minimum;
+        public object minimum;
 
         public bool? exclusiveMinimum;
 

--- a/Tests/Swagger.Net.Dummy.Core/Controllers/AnnotatedTypesController.cs
+++ b/Tests/Swagger.Net.Dummy.Core/Controllers/AnnotatedTypesController.cs
@@ -43,5 +43,8 @@ namespace Swagger.Net.Dummy.Controllers
         [MinLength(2)]
         [MaxLength(100)]
         public string Detail { get; set; }
+
+        [Required, Range(1.1, 32.9)]
+        public double Tax { get; set; }
     }
 }

--- a/Tests/Swagger.Net.Tests/Swagger/SchemaTests.cs
+++ b/Tests/Swagger.Net.Tests/Swagger/SchemaTests.cs
@@ -114,7 +114,7 @@ namespace Swagger.Net.Tests.Swagger
             {
                 PaymentWithMetadata = new
                 {
-                    required = new string[] { "Amount", "CardNumber", "ExpMonth", "ExpYear" },
+                    required = new[] { "Amount", "CardNumber", "ExpMonth", "ExpYear" },
                     properties = new
                     {
                         Amount = new
@@ -131,15 +131,15 @@ namespace Swagger.Net.Tests.Swagger
                         {
                             type = "integer",
                             format = "int32",
-                            maximum = 12.0,
-                            minimum = 1.0,
+                            maximum = 12,
+                            minimum = 1,
                         },
                         ExpYear = new
                         {
                             type = "integer",
                             format = "int32",
-                            maximum = 99.0,
-                            minimum = 14.0,
+                            maximum = 99,
+                            minimum = 14,
                         },
                         Note = new
                         {
@@ -169,7 +169,7 @@ namespace Swagger.Net.Tests.Swagger
             {
                 Payment = new
                 {
-                    required = new string[] { "Amount", "CardNumber", "ExpMonth", "ExpYear" },
+                    required = new[] { "Amount", "CardNumber", "ExpMonth", "ExpYear", "Tax" },
                     properties = new
                     {
                         Amount = new
@@ -188,8 +188,8 @@ namespace Swagger.Net.Tests.Swagger
                             example = "6",
                             type = "integer",
                             format = "int32",
-                            maximum = 12.0,
-                            minimum = 1.0,
+                            maximum = 12,
+                            minimum = 1,
                         },
                         ExpYear = new
                         {
@@ -197,8 +197,8 @@ namespace Swagger.Net.Tests.Swagger
                             example = "96",
                             type = "integer",
                             format = "int32",
-                            maximum = 99.0,
-                            minimum = 14.0,
+                            maximum = 99,
+                            minimum = 14,
                         },
                         Note = new
                         {
@@ -217,6 +217,13 @@ namespace Swagger.Net.Tests.Swagger
                             type = "string",
                             maxLength = 100,
                             minLength = 2,
+                        },
+                        Tax = new
+                        {
+                            type = "number",
+                            format = "double",
+                            maximum = 32.9,
+                            minimum = 1.1,
                         }
                     },
                     xml = JObject.Parse("{ \"name\": \"Payment\" }"),
@@ -374,8 +381,8 @@ namespace Swagger.Net.Tests.Swagger
                 required = true,
                 type = "integer",
                 format = "int32",
-                maximum = 2.0,
-                minimum = 1.0
+                maximum = 2,
+                minimum = 1
             });
             Assert.AreEqual(expected.ToString(), parameter.ToString());
         }


### PR DESCRIPTION
Current code is forcing the parsing to always output `double` typed maximum and minimum values.  E.g.

```
      "ExpYear": {
        "description": "Credit card expiration Year",
        "example": "96",
        "type": "integer",
        "format": "int32",
        "maximum": 99.0,
        "minimum": 14.0
      },
```

The `[Range]` attribute allows for `int`, `double`, and `object` values.  Switching the handling to just use the raw object, and json serialization handles properly outputting as the expected type formats.

```
      "ExpYear": {
        "description": "Credit card expiration Year",
        "example": "96",
        "type": "integer",
        "format": "int32",
        "maximum": 99,
        "minimum": 14
      },
```