### PR TITLE
Adding IgnoreObsoleteEnumConstants in order to filter emitted available values

### DIFF
--- a/Swagger.Net/Application/SwaggerDocsConfig.cs
+++ b/Swagger.Net/Application/SwaggerDocsConfig.cs
@@ -34,6 +34,7 @@ namespace Swagger.Net.Application
         private bool _ignoreObsoleteProperties;
         private bool _describeAllEnumsAsStrings;
         private bool _describeStringEnumsInCamelCase;
+        private bool _ignoreObsoleteEnumConstants;
         private bool _applyFiltersToAllSchemas = true;
         private bool _ignoreIsSpecifiedMembers = false;
         private readonly IList<Func<IOperationFilter>> _operationFilters;
@@ -59,6 +60,7 @@ namespace Swagger.Net.Application
             _ignoreObsoleteProperties = false;
             _describeAllEnumsAsStrings = false;
             _describeStringEnumsInCamelCase = false;
+            _ignoreObsoleteEnumConstants = false;
             _operationFilters = new List<Func<IOperationFilter>>();
             _documentFilters = new List<Func<IDocumentFilter>>();
             _xmlDocFactories = new List<Func<XPathDocument>>();
@@ -194,6 +196,11 @@ namespace Swagger.Net.Application
         {
             _describeAllEnumsAsStrings = true;
             _describeStringEnumsInCamelCase = camelCase;
+        }
+
+        public void IgnoreObsoleteEnumConstants()
+        {
+            _ignoreObsoleteEnumConstants = true;
         }
 
         public void IgnoreIsSpecifiedMembers()
@@ -340,6 +347,7 @@ namespace Swagger.Net.Application
                 schemaIdSelector: _schemaIdSelector,
                 describeAllEnumsAsStrings: _describeAllEnumsAsStrings,
                 describeStringEnumsInCamelCase: _describeStringEnumsInCamelCase,
+                ignoreObsoleteEnumConstants: _ignoreObsoleteEnumConstants,
                 applyFiltersToAllSchemas: _applyFiltersToAllSchemas,
                 ignoreIsSpecifiedMembers: _ignoreIsSpecifiedMembers,
                 operationFilters: operationFilters,

--- a/Swagger.Net/Swagger/Extensions/TypeExtensions.cs
+++ b/Swagger.Net/Swagger/Extensions/TypeExtensions.cs
@@ -38,9 +38,10 @@ namespace Swagger.Net
             return (chopIndex == -1) ? fullName : fullName.Substring(0, chopIndex);
         }
 
-        public static string[] GetEnumNamesForSerialization(this Type enumType)
+        public static string[] GetEnumNamesForSerialization(this Type enumType, bool excludeObsolete = false)
         {
             return enumType.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+                .Where(fieldInfo => !excludeObsolete || !fieldInfo.GetCustomAttributes<ObsoleteAttribute>().Any())
                 .Select(fieldInfo =>
                 {
                     var memberAttribute = fieldInfo.GetCustomAttributes(false).OfType<EnumMemberAttribute>().FirstOrDefault();
@@ -48,6 +49,14 @@ namespace Swagger.Net
                         ? fieldInfo.Name
                         : memberAttribute.Value;
                 })
+                .ToArray();
+        }
+
+        public static object[] GetEnumValuesForSerialization(this Type enumType, bool excludeObsolete = false)
+        {
+            return enumType.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+                .Where(fieldInfo => !excludeObsolete || !fieldInfo.GetCustomAttributes<ObsoleteAttribute>().Any())
+                .Select(fieldInfo => fieldInfo.GetRawConstantValue())
                 .ToArray();
         }
     }

--- a/Swagger.Net/Swagger/SchemaRegistry.cs
+++ b/Swagger.Net/Swagger/SchemaRegistry.cs
@@ -154,12 +154,14 @@ namespace Swagger.Net
                 var camelCase = _options.DescribeStringEnumsInCamelCase
                     || (stringEnumConverter != null && stringEnumConverter.CamelCaseText);
 
+                var enumValues = type.GetEnumNamesForSerialization(_options.IgnoreObsoleteEnumConstants);
+
                 return new Schema
                 {
                     type = "string",
                     @enum = camelCase
-                        ? type.GetEnumNamesForSerialization().Select(name => name.ToCamelCase()).ToArray()
-                        : type.GetEnumNamesForSerialization()
+                        ? enumValues.Select(name => name.ToCamelCase()).ToArray()
+                        : enumValues
                 };
             }
 
@@ -167,7 +169,7 @@ namespace Swagger.Net
             {
                 type = "integer",
                 format = "int32",
-                @enum = type.GetEnumValues().Cast<object>().ToArray()
+                @enum = type.GetEnumValuesForSerialization(_options.IgnoreObsoleteEnumConstants)
             };
         }
 

--- a/Swagger.Net/Swagger/SwaggerGeneratorOptions.cs
+++ b/Swagger.Net/Swagger/SwaggerGeneratorOptions.cs
@@ -22,6 +22,7 @@ namespace Swagger.Net
             Func<Type, string> schemaIdSelector = null,
             bool describeAllEnumsAsStrings = false,
             bool describeStringEnumsInCamelCase = false,
+            bool ignoreObsoleteEnumConstants = false,
             bool applyFiltersToAllSchemas = false,
             bool ignoreIsSpecifiedMembers = false,
             IEnumerable<IOperationFilter> operationFilters = null,
@@ -43,6 +44,7 @@ namespace Swagger.Net
             SchemaIdSelector = schemaIdSelector ?? DefaultSchemaIdSelector;
             DescribeAllEnumsAsStrings = describeAllEnumsAsStrings;
             DescribeStringEnumsInCamelCase = describeStringEnumsInCamelCase;
+            IgnoreObsoleteEnumConstants = ignoreObsoleteEnumConstants;
             ApplyFiltersToAllSchemas = applyFiltersToAllSchemas;
             IgnoreIsSpecifiedMembers = ignoreIsSpecifiedMembers;
             OperationFilters = operationFilters ?? new List<IOperationFilter>();
@@ -79,11 +81,14 @@ namespace Swagger.Net
 
         public bool DescribeStringEnumsInCamelCase { get; private set; }
 
+        public bool IgnoreObsoleteEnumConstants { get; private set; }
+
+
         public bool ApplyFiltersToAllSchemas { get; private set; }
 
         public bool IgnoreIsSpecifiedMembers { get; private set; }
 
-        public Func<ApiDescription, string> OperationIdResolver {get; }
+        public Func<ApiDescription, string> OperationIdResolver { get; }
 
         public IEnumerable<IOperationFilter> OperationFilters { get; private set; }
 

--- a/Tests/Swagger.Net.Dummy.Core/Controllers/ObsoleteEnumsController.cs
+++ b/Tests/Swagger.Net.Dummy.Core/Controllers/ObsoleteEnumsController.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Web.Http;
+
+namespace Swagger.Net.Dummy.Controllers
+{
+    public class ObsoleteEnumsController : ApiController
+    {
+        public int Get(Colors color)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public enum Colors
+    {
+        [Obsolete]
+        Red = 0,
+
+        [Obsolete]
+        Blue = 1,
+
+        Green = 2
+    }
+}

--- a/Tests/Swagger.Net.Dummy.Core/Swagger.Net.Dummy.Core.csproj
+++ b/Tests/Swagger.Net.Dummy.Core/Swagger.Net.Dummy.Core.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Controllers\FromBodyParamsController.cs" />
     <Compile Include="Controllers\NestedEnumController.cs" />
     <Compile Include="Controllers\BlobController.cs" />
+    <Compile Include="Controllers\ObsoleteEnumsController.cs" />
     <Compile Include="Controllers\SerializableController.cs" />
     <Compile Include="Controllers\BaseChildController.cs" />
     <Compile Include="Controllers\BaseController.cs" />

--- a/Tests/Swagger.Net.Tests/Swagger/SchemaTests.cs
+++ b/Tests/Swagger.Net.Tests/Swagger/SchemaTests.cs
@@ -776,6 +776,41 @@ namespace Swagger.Net.Tests.Swagger
         }
 
         [Test]
+        public void It_exposes_config_to_ignore_all_int_enum_constants_that_are_obsolete()
+        {
+            SetUpDefaultRouteFor<ObsoleteEnumsController>();
+            SetUpHandler(c =>
+            {
+                c.IgnoreObsoleteEnumConstants();
+            });
+
+
+            var swagger = GetContent<JObject>(TEMP_URI.DOCS);
+            var @enum = swagger["paths"]["/obsoleteenums"]["get"]["parameters"][0]["enum"];
+            var expectedEnum = JArray.FromObject(new int[] { 2 });
+
+            Assert.AreEqual(expectedEnum.ToString(), @enum.ToString());
+        }
+
+        [Test]
+        public void It_exposes_config_to_ignore_all_string_enum_constants_that_are_obsolete()
+        {
+            SetUpDefaultRouteFor<ObsoleteEnumsController>();
+            SetUpHandler(c =>
+            {
+                c.DescribeAllEnumsAsStrings();
+                c.IgnoreObsoleteEnumConstants();
+            });
+
+
+            var swagger = GetContent<JObject>(TEMP_URI.DOCS);
+            var @enum = swagger["paths"]["/obsoleteenums"]["get"]["parameters"][0]["enum"];
+            var expectedEnum = JArray.FromObject(new string[] { "Green" });
+
+            Assert.AreEqual(expectedEnum.ToString(), @enum.ToString());
+        }
+
+        [Test]
         public void It_exposes_config_to_workaround_multiple_types_with_the_same_class_name()
         {
             SetUpDefaultRouteFor<ConflictingTypesController>();

--- a/Tests/Swagger.Net.Tests/Swagger/TypeExtensionsTests.cs
+++ b/Tests/Swagger.Net.Tests/Swagger/TypeExtensionsTests.cs
@@ -37,6 +37,20 @@ namespace Swagger.Net.Swagger
         }
 
         [Test]
+        public void GetEnumNamesForSerialization_ExcludesObsoleteAttributes()
+        {
+            var enumNames = typeof(EnumWithObsoleteAttributes).GetEnumNamesForSerialization(excludeObsolete: true);
+            CollectionAssert.AreEqual(new[] { "Value3" }, enumNames);
+        }
+
+        [Test]
+        public void GetEnumValuesForSerialization_ExcludesObsoleteAttributes()
+        {
+            var enumValues = typeof(EnumWithObsoleteAttributes).GetEnumValuesForSerialization(excludeObsolete: true);
+            CollectionAssert.AreEqual(new[] { 2 }, enumValues);
+        }
+
+        [Test]
         public void FullNameSansTypeParameters_Test()
         {
             var mock = new Mock<Type>();
@@ -56,6 +70,17 @@ namespace Swagger.Net.Swagger
 
             [EnumMember(Value = "value-2")]
             Value2 = 1
+        }
+
+        public enum EnumWithObsoleteAttributes
+        {
+            [Obsolete]
+            Value1 = 0,
+
+            [Obsolete]
+            Value2 = 1,
+
+            Value3 = 2
         }
     }
 }


### PR DESCRIPTION
config
```
   c.DescribeAllEnumsAsStrings();
   c.IgnoreObsoleteEnumConstants();
```

enum
```
public  enum Filter 
{
   first, 

   [Obsolete]
   second, 

   third
};
```

controller snippet
```
[Route("test")]
public HttpResponseMessage Get(Filter filter = Filter.first)
```

snippet of generated swagger.json:
```
"parameters": [
                    {
                        "default": "first",
                        "enum": [
                            "first",
                            "third"
                        ],
                        "in": "query",
                        "name": "filter",
                        "required": false,
                        "type": "string"
                    }]
```