### PR TITLE
Fix NullReferenceException from XmlCommentsIdHelper.

### DIFF
--- a/Swagger.Net/Swagger/XmlComments/XmlCommentsIdHelper.cs
+++ b/Swagger.Net/Swagger/XmlComments/XmlCommentsIdHelper.cs
@@ -64,7 +64,7 @@ namespace Swagger.Net.XmlComments
         {
             if (type.IsNested)
             {
-                AppendTypeName(type.DeclaringType, builder, true, genericParametersPositions);
+                AppendTypeName(type.DeclaringType, builder, genericParametersPositions != null, GetTypeParameterPositions(type.DeclaringType));
                 builder.Append(".");
             }
 

--- a/Tests/Swagger.Net.Dummy.Core/Controllers/NestingClassController.cs
+++ b/Tests/Swagger.Net.Dummy.Core/Controllers/NestingClassController.cs
@@ -1,0 +1,24 @@
+﻿using System.Web.Http;
+
+namespace Swagger.Net.Dummy.Controllers
+{
+    
+    public class NestingBaseClassController<T> : ApiController
+    {
+        public class NestedClass
+        {
+            /// <summary>
+            /// Property that is of generic type taken from the class that this class is nested into
+            /// </summary>
+            public T GenericallyTypedProperty { get; set; }
+        }
+    }
+
+    public class NestingClassController : NestingBaseClassController<string>
+    {
+        public NestedClass Get(int x)
+        {
+            return new NestedClass();
+        }
+    }
+}

--- a/Tests/Swagger.Net.Dummy.Core/Swagger.Net.Dummy.Core.csproj
+++ b/Tests/Swagger.Net.Dummy.Core/Swagger.Net.Dummy.Core.csproj
@@ -66,6 +66,7 @@
     <Compile Include="App_Start\CachingSwaggerProvider.cs" />
     <Compile Include="Controllers\FromHeaderParamsController.cs" />
     <Compile Include="Controllers\FromBodyParamsController.cs" />
+    <Compile Include="Controllers\NestingClassController.cs" />
     <Compile Include="Controllers\NestedEnumController.cs" />
     <Compile Include="Controllers\BlobController.cs" />
     <Compile Include="Controllers\ObsoleteEnumsController.cs" />

--- a/Tests/Swagger.Net.Dummy.Core/XmlComments.xml
+++ b/Tests/Swagger.Net.Dummy.Core/XmlComments.xml
@@ -4,6 +4,11 @@
         <name>Swagger.Net.Dummy.Core</name>
     </assembly>
     <members>
+        <member name="P:Swagger.Net.Dummy.Controllers.NestingBaseClassController`1.NestedClass.GenericallyTypedProperty">
+            <summary>
+            Property that is of generic type taken from the class that this class is nested into
+            </summary>
+        </member>
         <member name="M:Swagger.Net.Dummy.Controllers.NestedEnum`1.Get(System.Nullable{Swagger.Net.Dummy.Controllers.NestedEnum{`0}.Giorno})">
             <summary>NestedEnum test</summary>
         </member>

--- a/Tests/Swagger.Net.Dummy.WebHost/XmlComments.xml
+++ b/Tests/Swagger.Net.Dummy.WebHost/XmlComments.xml
@@ -4,6 +4,11 @@
         <name>Swagger.Net.Dummy.Core</name>
     </assembly>
     <members>
+        <member name="P:Swagger.Net.Dummy.Controllers.NestingBaseClassController`1.NestedClass.GenericallyTypedProperty">
+            <summary>
+            Property that is of generic type taken from the class that this class is nested into
+            </summary>
+        </member>
         <member name="M:Swagger.Net.Dummy.Controllers.NestedEnum`1.Get(System.Nullable{Swagger.Net.Dummy.Controllers.NestedEnum{`0}.Giorno})">
             <summary>NestedEnum test</summary>
         </member>

--- a/Tests/Swagger.Net.Tests/Swagger/XmlCommentsTests.cs
+++ b/Tests/Swagger.Net.Tests/Swagger/XmlCommentsTests.cs
@@ -20,6 +20,7 @@ namespace Swagger.Net.Tests.Swagger
             SetUpAttributeRoutesFrom(typeof(XmlAnnotatedController).Assembly);
             SetUpDefaultRouteFor<XmlAnnotatedController>();
             SetUpDefaultRouteFor<BaseChildController>();
+            SetUpDefaultRouteFor<NestingClassController>();
             SetUpHandler();
         }
 
@@ -249,6 +250,15 @@ namespace Swagger.Net.Tests.Swagger
             var displayNameProperty = swagger["definitions"]["AccountPreferences"]["properties"]["DisplayName"];
             Assert.IsNotNull(displayNameProperty["description"]);
             Assert.AreEqual("Provide a display name to use instead of Username when signed in", displayNameProperty["description"].ToString());
+        }
+
+        [Test]
+        public void It_handles_nested_generic_class_properties()
+        {
+            var swagger = GetContent<JObject>(TEMP_URI.DOCS);
+            var displayNameProperty = swagger["definitions"]["NestedClassOfString"]["properties"]["GenericallyTypedProperty"];
+            Assert.IsNotNull(displayNameProperty["description"]);
+            Assert.AreEqual("Property that is of generic type taken from the class that this class is nested into", displayNameProperty["description"].ToString());
         }
 
         [Test]


### PR DESCRIPTION
This PR is my proposed fix to issue #81 

Add a test to cater for nesting classes within generic classes when checking XML comments.
Changed AppendTypeName to cater for the nested class.

Thanks for your time.