### PR TITLE
Preserve existing operation responses when parsing XML action comments.

### DIFF
--- a/Swagger.Net/Swagger/XmlComments/ApplyXmlActionComments.cs
+++ b/Swagger.Net/Swagger/XmlComments/ApplyXmlActionComments.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Web.Http;
 using System.Web.Http.Controllers;
@@ -105,6 +106,8 @@ namespace Swagger.Net.XmlComments
 
                     operation.responses[statusCode] = response;
                 }
+
+                operation.responses = new SortedDictionary<string, Response>(operation.responses);
             }
         }
 

--- a/Swagger.Net/Swagger/XmlComments/ApplyXmlActionComments.cs
+++ b/Swagger.Net/Swagger/XmlComments/ApplyXmlActionComments.cs
@@ -84,19 +84,25 @@ namespace Swagger.Net.XmlComments
 
             if (responseNodes.Count > 0)
             {
-                var successResponse = operation.responses.First().Value;
-                operation.responses.Clear();
+                var successResponse = operation.responses.First();
 
                 while (responseNodes.MoveNext())
                 {
                     var statusCode = responseNodes.Current.GetAttribute("code", "");
+                    var isSuccessCode = statusCode.StartsWith("2");
                     var description = responseNodes.Current.ExtractContent();
 
                     var response = new Response
                     {
                         description = description,
-                        schema = statusCode.StartsWith("2") ? successResponse.schema : null
+                        schema = isSuccessCode ? successResponse.Value.schema : null
                     };
+
+                    if (isSuccessCode)
+                    {
+                        operation.responses.Remove(successResponse);
+                    }
+
                     operation.responses[statusCode] = response;
                 }
             }

--- a/Tests/Swagger.Net.Dummy.Core/Controllers/SwaggerAnnotatedController.cs
+++ b/Tests/Swagger.Net.Dummy.Core/Controllers/SwaggerAnnotatedController.cs
@@ -26,6 +26,13 @@ namespace Swagger.Net.Dummy.Controllers
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Get message by Id
+        /// </summary>
+        /// <param name="id">The id</param>
+        /// <returns>The message.</returns>
+        /// <response code="404">Not found</response>
+        [SwaggerResponse(HttpStatusCode.OK, Type = typeof(Message))]
         [SwaggerOperationFilter(typeof(AddGetMessageExamples))]
         public Message GetById(int id)
         {

--- a/Tests/Swagger.Net.Dummy.Core/XmlComments.xml
+++ b/Tests/Swagger.Net.Dummy.Core/XmlComments.xml
@@ -60,6 +60,14 @@
             <summary>Credit card expiration Year</summary>
             <example>96</example>
         </member>
+        <member name="M:Swagger.Net.Dummy.Controllers.SwaggerAnnotatedController.GetById(System.Int32)">
+            <summary>
+            Get message by Id
+            </summary>
+            <param name="id">The id</param>
+            <returns>The message.</returns>
+            <response code="404">Not found</response>
+        </member>
         <member name="T:Swagger.Net.Dummy.Controllers.XmlAnnotatedController">
             <summary>
             XmlAnnotatedController

--- a/Tests/Swagger.Net.Dummy.WebHost/XmlComments.xml
+++ b/Tests/Swagger.Net.Dummy.WebHost/XmlComments.xml
@@ -60,6 +60,14 @@
             <summary>Credit card expiration Year</summary>
             <example>96</example>
         </member>
+        <member name="M:Swagger.Net.Dummy.Controllers.SwaggerAnnotatedController.GetById(System.Int32)">
+            <summary>
+            Get message by Id
+            </summary>
+            <param name="id">The id</param>
+            <returns>The message.</returns>
+            <response code="404">Not found</response>
+        </member>
         <member name="T:Swagger.Net.Dummy.Controllers.XmlAnnotatedController">
             <summary>
             XmlAnnotatedController

--- a/Tests/Swagger.Net.Tests/Swagger/AnnotationsTests.cs
+++ b/Tests/Swagger.Net.Tests/Swagger/AnnotationsTests.cs
@@ -115,6 +115,36 @@ namespace Swagger.Net.Tests.Swagger
                 });
             Assert.AreEqual(expected.ToString(), getResponses.ToString());
         }
+        [Test]
+        public void It_documents_responses_from_swagger_response_attributes_and_xml_comments()
+        {
+            var swagger = GetContent<JObject>(TEMP_URI.DOCS);
+            var getResponses = swagger["paths"]["/swaggerannotated/{id}"]["get"]["responses"];
+            var expected = JObject.FromObject(new Dictionary<string, object>()
+                {
+                    {
+                        "200", new
+                        {
+                            description = "OK",
+                            schema = JObject.Parse("{ \"$ref\": \"#/definitions/Message\" }"),
+                            examples = JObject.Parse("{ \"application/json\": { \"title\": \"A message\", \"content\": \"Some content\" } }")
+                        }
+                    },
+                    {
+                        "400", new
+                        {
+                            description = "Bad request"
+                        }
+                    },
+                    {
+                        "404", new
+                        {
+                            description = "Not found"
+                        }
+                    }
+                });
+            Assert.AreEqual(expected.ToString(), getResponses.ToString());
+        }
 
         [Test]
         public void It_documents_responses_from_swagger_response_attributes_patch()


### PR DESCRIPTION
Currently, if there are any XML response comments, all existing responses already created using the SwaggerResponseAttribute are removed. This leads to unexpected scenarios where attribute responses are ignored by Swagger-Net. As attribute responses are more robust than XML response comments, they should be retained. This change preserves the attribute responses and allows developers to define responses using both methods.