### PR TITLE
Enable optional typeName of GetOrRegister method to be used as the Definitions key

### DIFF
--- a/Swagger.Net/Swagger/SchemaRegistry.cs
+++ b/Swagger.Net/Swagger/SchemaRegistry.cs
@@ -68,18 +68,18 @@ namespace Swagger.Net
             var dictionaryContract = jsonContract as JsonDictionaryContract;
             if (dictionaryContract != null)
                 return dictionaryContract.IsSelfReferencing()
-                    ? CreateRefSchema(type)
+                    ? CreateRefSchema(type, typeName)
                     : FilterSchema(CreateDictionarySchema(dictionaryContract), jsonContract);
 
             var arrayContract = jsonContract as JsonArrayContract;
             if (arrayContract != null)
                 return arrayContract.IsSelfReferencing()
-                    ? CreateRefSchema(type)
+                    ? CreateRefSchema(type, typeName)
                     : FilterSchema(CreateArraySchema(arrayContract, true, typeName), jsonContract);
 
             var objectContract = jsonContract as JsonObjectContract;
             if (objectContract != null && !objectContract.IsAmbiguous())
-                return CreateRefSchema(type);
+                return CreateRefSchema(type, typeName);
 
             // Fallback to abstract "object"
             return FilterSchema(new Schema { type = "object" }, jsonContract);
@@ -247,11 +247,11 @@ namespace Swagger.Net
             return s;
         }
 
-        private Schema CreateRefSchema(Type type)
+        private Schema CreateRefSchema(Type type, string typeName)
         {
             if (!_workItems.ContainsKey(type))
             {
-                var schemaId = _options.SchemaIdSelector(type);
+                var schemaId = typeName ?? _options.SchemaIdSelector(type);
                 if (_workItems.Any(entry => entry.Value.SchemaId == schemaId))
                 {
                     var conflictingType = _workItems.First(entry => entry.Value.SchemaId == schemaId).Key;

--- a/Tests/Swagger.Net.Tests/CoreUnitTests/SchemaRegistryTests.cs
+++ b/Tests/Swagger.Net.Tests/CoreUnitTests/SchemaRegistryTests.cs
@@ -48,6 +48,36 @@ namespace Swagger.Net.Tests.CoreUnitTests
         }
 
         [Test]
+        public void GetOrRegister_withoutTypeName()
+        {
+            string SchemaIdSelector(Type arg) => arg.FullName;
+            var mock = new Mock<JsonSerializerSettings>();
+            var opt = new SwaggerGeneratorOptions(schemaIdSelector: SchemaIdSelector);
+            var schema = new SchemaRegistry(mock.Object, opt);
+            var modelType = new {Property1 = "Property1"}.GetType();
+
+            schema.GetOrRegister(modelType);
+
+            Assert.That(schema.Definitions, Is.Not.Null.And.ContainKey(SchemaIdSelector(modelType)));
+            Assert.That(schema.Definitions[SchemaIdSelector(modelType)].properties, Is.Not.Null.And.ContainKey("Property1"));
+        }
+
+        [Test]
+        public void GetOrRegister_withTypeName()
+        {
+            var mock = new Mock<JsonSerializerSettings>();
+            var opt = new SwaggerGeneratorOptions();
+            var schema = new SchemaRegistry(mock.Object, opt);
+            var model = new {Property1 = "Property1"};
+            const string typeName = "testTypeName";
+
+            schema.GetOrRegister(model.GetType(), typeName);
+
+            Assert.That(schema.Definitions, Is.Not.Null.And.ContainKey(typeName));
+            Assert.That(schema.Definitions[typeName].properties, Is.Not.Null.And.ContainKey("Property1"));
+        }
+
+        [Test]
         public void CreateObjectSchema_Null()
         {
             var mock = new Mock<JsonSerializerSettings>();


### PR DESCRIPTION
Hi,

I noticed what seems to be some incorrect behavour when using the optional `typeName` of the `SchemaRegistry`.

Before this change, calling `schemaRegistory.GetOrRegister(type, typeName)` or `schemaRegistory.CreateInlineSchema(type, typeName)` would not cause the new `Schema` added to the `Definitions` dictionary within `schemaRegistory` to be keyed with the `typeName` specified.

I've made a change that flows the `typeName` through the `CreateInlineSchema` method and into the `CreateRefSchema` method which I've added the `typeName` parameter to. `CreateRefSchema` can now correctly set the `SchemaId`, using `typeName` if supplied, or falling back to original behaviour of `SchemaIdSelector(type)` if not supplied.

(No public method signitures have been changed.)

I hope you'll find this change acceptable and I appologies if just opening a PR is not your prefered way of interaction.