### PR TITLE
Fix to not add range to schema for DateTime range

### DIFF
--- a/Swagger.Net/Swagger/Extensions/SchemaExtensions.cs
+++ b/Swagger.Net/Swagger/Extensions/SchemaExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json.Serialization;
+using System;
 using Swagger.Net.Swagger.Annotations;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
@@ -22,7 +23,8 @@ namespace Swagger.Net
 
         public static void AddRange(this Schema schema, object attribute)
         {
-            if (attribute is RangeAttribute range)
+            if (attribute is RangeAttribute range 
+                && (range.OperandType == typeof(Int32) || range.OperandType == typeof(Double)))
             {
                 schema.minimum = range.Minimum;
                 schema.maximum = range.Maximum;

--- a/Tests/Swagger.Net.Tests/Swagger.Net.Tests.csproj
+++ b/Tests/Swagger.Net.Tests/Swagger.Net.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="..\..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\..\packages\NUnit.3.10.1\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -164,6 +165,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit.3.10.1\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Tests/Swagger.Net.Tests/packages.config
+++ b/Tests/Swagger.Net.Tests/packages.config
@@ -11,6 +11,7 @@
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net45" />
   <package id="NUnit" version="3.10.1" targetFramework="net45" />
   <package id="NUnit.ConsoleRunner" version="3.10.0" targetFramework="net45" />
+  <package id="NUnit3TestAdapter" version="3.17.0" targetFramework="net45" />
   <package id="OpenCover" version="4.7.922" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="System.Threading.Tasks.Extensions" version="4.4.0" targetFramework="net45" />


### PR DESCRIPTION
Added logic to AddRange method to check if it is an Int32 or Double. If it is not, then it will not add the range attribute to the schema. OpenAPI only supports integer ranges (https://swagger.io/docs/specification/data-models/data-types/#range)