### PR TITLE
Update SchemaExtensions.cs

### DIFF
--- a/Swagger.Net/Swagger/Extensions/SchemaExtensions.cs
+++ b/Swagger.Net/Swagger/Extensions/SchemaExtensions.cs
@@ -89,7 +89,10 @@ namespace Swagger.Net
                 return schema;
 
             var attrib = propInfo.GetCustomAttributes(false).OfType<SwaggerDescriptionAttribute>().FirstOrDefault();
-            schema.description = attrib?.Description;
+            var description = attrib?.Description;
+            if (description != null)
+                schema.description = description;
+
             return schema;
         }
 


### PR DESCRIPTION
Set schema's description only if has SwaggerDescriptionAttribute applied and the description is not null, in case overwrite the description from custom SchemaFilter or ModelFilter