### PR TITLE
fix: update the nuspec Newtonsoft.Json reference

### DIFF
--- a/Swagger.Net/Swagger.Net.nuspec
+++ b/Swagger.Net/Swagger.Net.nuspec
@@ -16,7 +16,7 @@
     <dependencies>
       <dependency id="Microsoft.AspNet.WebApi.Core" version="5.2.4" />
       <dependency id="Microsoft.AspNet.WebApi.WebHost" version="5.2.4" />
-      <dependency id="Newtonsoft.Json" version="13.0.1" />
+      <dependency id="Newtonsoft.Json" version="13.0.3" />
       <dependency id="FromHeaderAttribute" version="2.0.4" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
I saw the recent PR #130, but it didn't update the nuspec file, so NuGet still believes it references 13.0.1 instead of 13.0.3